### PR TITLE
Task

### DIFF
--- a/lib/concurrency.ex
+++ b/lib/concurrency.ex
@@ -4,27 +4,11 @@ defmodule Concurrency do
   """
   @spec seed((... -> any()), [any()], non_neg_integer()) :: any()
   def seed(fun, args, count) do
-    Enum.map(
-      1..count,
-      fn _ ->
-        self_pid = self()
-        spawn(fn -> send(self_pid, apply(fun, args)) end)
-      end
-    )
+    Enum.map(1..count, fn _ -> Task.async(fn -> apply(fun, args) end) end)
   end
 
   @spec harvest(any()) :: [any()]
   def harvest(list) do
-    Enum.map(
-      list,
-      fn _ ->
-        receive do
-          {status, time} -> {status, time}
-        after
-          # in case of throttling
-          1000 -> {:error, 1000}
-        end
-      end
-    )
+    Enum.map(list, &Task.await(&1))
   end
 end


### PR DESCRIPTION
Using `Task` for concurrent requests (`Concurrency`s API remains the same).